### PR TITLE
最新动态模块增加toc右侧导航目录 默认时间格式修改 (#241)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -46,8 +46,8 @@ languageName ="中文"
 contentDir = "content"
 # Weight used for sorting.
 weight = 1
-time_format_default = "2020.12.01"
-time_format_blog = "2020.12.01"
+time_format_default = "2020-12-01"
+time_format_blog = "2020-12-01"
 
 [module]
   [module.hugoVersion]

--- a/static/js/product_news.js
+++ b/static/js/product_news.js
@@ -1,0 +1,16 @@
+//产品动态无法自动生成toc目录列表 特用js生成
+$(function(){
+	if($('#TableOfContents li').length == 0){
+		var h2_title = $('section.product_dynamics h2');
+		if(h2_title.length >0){
+			var result = '<ul>';
+			h2_title.each(function(){
+				var h2_id = $(this).attr('id');
+				var h2_name = $(this).html();
+				result += '<li><a href="#'+h2_id+'">'+h2_name+'</a></li>';
+			});
+			result += '</ul>';
+			$('#TableOfContents').html(result);
+		}
+	}
+})

--- a/themes/docsy/layouts/_default/content.html
+++ b/themes/docsy/layouts/_default/content.html
@@ -28,7 +28,7 @@
 						<div class="timeline-outer-line timeline-product"></div>
 						<div class="col-sm-12 timeline-outer">
 							<p>{{ .time }}</p>
-							<h2>{{ .title }}</h2>
+							<h2 id="{{ .title }}">{{ .title }}</h2>
 							<p class="product_dynamics_p">{{ .content | markdownify  }}</p>
 							{{ if .url}}
 							<a href="{{ .url }}">查看相关文档 <img src="/images/icons/black.svg"></a>
@@ -40,6 +40,7 @@
 			</div>
 		</div>
 	</section>
+	<script src="/js/product_news.js"></script>
 	{{ end }}
 	{{ .Content }}
 	<!-- {{ if (and (not .Params.hide_feedback) (.Site.Params.ui.feedback.enable) (.Site.GoogleAnalytics)) }}

--- a/themes/docsy/layouts/partials/toc.html
+++ b/themes/docsy/layouts/partials/toc.html
@@ -1,11 +1,11 @@
 <!-- {{ partial "page-meta-links.html" . }} -->
 {{ if not .Params.notoc }}
-{{ if ge (len .TableOfContents) 33 }}
+
 <h3 class="nav-title">本页目录</h3>
 {{ with .TableOfContents }}
 
 {{ . }}
 
-{{ end }}
+
 {{ end }}
 {{ end }}


### PR DESCRIPTION
* 移动端bugfix

* 左侧导航长度不够问题解决  pdf下载翻页样式

* 外链 统一顶层打开  文档页右侧聚焦  左侧目录3级目录调整  单级目录样式调整

* 手机端 目录树调整

* Create main.yml

* console 760 以下适配  去除console时google字体

* 去除workflow

* 最新动态模块增加toc右侧导航目录

* 默认时间格式修改

Co-authored-by: yuancong@yunify.com <19890912Cc!>